### PR TITLE
Release 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
-#!/usr/bin/env python
+from setuptools import setup, find_packages
 
 __package_name__ = "hierarchical_conf"
 __version__ = "1.0.0"
 __repository_url__ = "https://github.com/quintoandar/hierarchical-conf"
 
-from setuptools import setup, find_packages
 
 with open("README.md") as readme_file:
     readme = readme_file.read()
@@ -12,13 +11,14 @@ with open("README.md") as readme_file:
 with open("requirements.txt") as f:
     requirements = [line for line in f.read().splitlines() if len(line) > 0]
 
-with open("requirements.dev.txt") as f:
+with open("requirements.test.txt") as f:
     test_requirements = [line for line in f.read().splitlines() if len(line) > 0]
 
 setup(
     name=__package_name__,
     description="A tool for loading settings from files hierarchically",
     long_description=readme,
+    long_description_content_type="text/markdown",
     keywords="hierarchical-conf",
     version=__version__,
     url=__repository_url__,


### PR DESCRIPTION
## Why? :open_book:
It was missing to define the description content type for publishing the docs inside Pypi's page.
Patch for #10

## What? :wrench:
- add the missing key `long_description_content_type="text/markdown",`

## Type of change :file_cabinet:
- [x] Release

## How everything was tested? :straight_ruler:
`make package` & `twine check dist dist/*`
<img width="479" alt="image" src="https://user-images.githubusercontent.com/13151948/184715729-45bbcf68-6107-48e1-bf95-0857e500bc56.png">