### PR TITLE
Load only existent files

### DIFF
--- a/hierarchical_conf/hierarchical_conf.py
+++ b/hierarchical_conf/hierarchical_conf.py
@@ -1,6 +1,8 @@
 """Hierarchical Conf main class."""
+import logging
 import os
 from collections.abc import Mapping
+from os.path import isfile
 from typing import Union, List, Dict, Any, Mapping as MappingType
 
 import yaml
@@ -71,17 +73,24 @@ class HierarchicalConf:
         configuration_files = []
         for path in searched_paths:
             environment_conf_file = f"{path}/{self._config_file_name}"
-            self._validate_if_config_file_exists(environment_conf_file)
-            configuration_files.append(environment_conf_file)
+            if self._config_file_exists(environment_conf_file):
+                configuration_files.append(environment_conf_file)
         return configuration_files
 
     @staticmethod
-    def _validate_if_config_file_exists(config_file_path: str) -> None:
-        if not os.path.isfile(config_file_path):
-            raise FileNotFoundError(
-                f"expected_file={config_file_path}, "
-                "msg=This configuration file was not found in the given path."
-            )
+    def _config_file_exists(config_file_path: str) -> bool:
+        """
+        Checks if the configuration file path exists.
+        :param config_file_path: DAG's or Spark Job's configuration file path
+        """
+        if isfile(config_file_path):
+            return True
+
+        logging.warning(
+            f"msg=This configuration file was not found in the given path,"
+            f"file={config_file_path}"
+        )
+        return False
 
     @staticmethod
     def _read_configuration(conf_file_path: str) -> Union[Any, Dict[str, Any]]:

--- a/hierarchical_conf/hierarchical_conf.py
+++ b/hierarchical_conf/hierarchical_conf.py
@@ -81,7 +81,8 @@ class HierarchicalConf:
     def _config_file_exists(config_file_path: str) -> bool:
         """
         Checks if the configuration file path exists.
-        :param config_file_path: DAG's or Spark Job's configuration file path
+
+        :param config_file_path: the configuration file path
         """
         if isfile(config_file_path):
             return True

--- a/tests/integration/test_hierarchical_conf.py
+++ b/tests/integration/test_hierarchical_conf.py
@@ -41,3 +41,22 @@ class TestHierarchicalConf:
 
         # assert
         assert hierarchical_conf.configs == expected_confs
+
+    @mock.patch.dict(os.environ, {"ENVIRONMENT": "integration_env"})
+    def test_non_existent_files(self):
+        # arrange
+        expected_confs = {
+            "key1": "value of key1...",
+            "key2": "value of key2...",
+            "key3": {"foo": "value of key3.foo"}
+        }
+        integration_tests_folder = dirname(__file__)
+        precedence_case_folder = dirname(__file__) + "/different_path/"
+
+        # act
+        hierarchical_conf = HierarchicalConf(
+            searched_paths=[integration_tests_folder, precedence_case_folder]
+        )
+
+        # assert
+        assert hierarchical_conf.configs == expected_confs

--- a/tests/integration/test_hierarchical_conf.py
+++ b/tests/integration/test_hierarchical_conf.py
@@ -48,7 +48,7 @@ class TestHierarchicalConf:
         expected_confs = {
             "key1": "value of key1...",
             "key2": "value of key2...",
-            "key3": {"foo": "value of key3.foo"}
+            "key3": {"foo": "value of key3.foo"},
         }
         integration_tests_folder = dirname(__file__)
         precedence_case_folder = dirname(__file__) + "/different_path/"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -6,7 +6,7 @@ from hierarchical_conf.hierarchical_conf import HierarchicalConf
 
 
 @pytest.fixture()
-@mock.patch.object(HierarchicalConf, "_validate_if_config_file_exists")
+@mock.patch.object(HierarchicalConf, "_config_file_exists")
 @mock.patch.object(HierarchicalConf, "_read_configuration")
-def hierarchical_conf(mock_read_configuration, mock_validate_if_config_file_exists):
+def hierarchical_conf(mock_read_configuration, mock_config_file_exists):
     return HierarchicalConf(searched_paths=[mock.ANY])

--- a/tests/unit/test_hierarchical_conf.py
+++ b/tests/unit/test_hierarchical_conf.py
@@ -31,10 +31,10 @@ class TestHierarchicalConf:
         mock_search_configurations_files.assert_called_once_with(searched_paths)
         mock_load_configurations_from_files.assert_called_once_with()
 
-    @mock.patch.object(HierarchicalConf, "_validate_if_config_file_exists")
+    @mock.patch.object(HierarchicalConf, "_config_file_exists")
     @mock.patch.object(HierarchicalConf, "_read_configuration")
     def test_get_conf_with_one_file(
-        self, mock_read_configuration, mock_validate_if_config_file_exists
+        self, mock_read_configuration, mock_config_file_exists
     ):
         # arrange
         expected_confs = {"key1": "val1", "key2": "val2"}
@@ -48,10 +48,10 @@ class TestHierarchicalConf:
         # assert
         assert hconf.configs == expected_confs
 
-    @mock.patch.object(HierarchicalConf, "_validate_if_config_file_exists")
+    @mock.patch.object(HierarchicalConf, "_config_file_exists")
     @mock.patch.object(HierarchicalConf, "_read_configuration")
     def test_get_conf_with_multiple_files(
-        self, mock_read_configuration, mock_validate_if_config_file_exists
+        self, mock_read_configuration, mock_config_file_exists
     ):
         # arrange
         expected_confs = {
@@ -82,10 +82,10 @@ class TestHierarchicalConf:
         assert hconf.configs == expected_confs
         assert hconf.get_config("key2") == "another value"
 
-    @mock.patch.object(HierarchicalConf, "_validate_if_config_file_exists")
+    @mock.patch.object(HierarchicalConf, "_config_file_exists")
     @mock.patch.object(HierarchicalConf, "_read_configuration")
     def test_existent_config(
-        self, mock_read_configuration, mock_validate_if_config_file_exists
+        self, mock_read_configuration, mock_config_file_exists
     ):
         # arrange
         mock_configs = {"a": 1, "b": 2}
@@ -97,10 +97,10 @@ class TestHierarchicalConf:
         # assert
         assert hconf.get_config("a") == 1
 
-    @mock.patch.object(HierarchicalConf, "_validate_if_config_file_exists")
+    @mock.patch.object(HierarchicalConf, "_config_file_exists")
     @mock.patch.object(HierarchicalConf, "_read_configuration")
     def test_nonexistent_config(
-        self, mock_read_configuration, mock_validate_if_config_file_exists
+        self, mock_read_configuration, mock_config_file_exists
     ):
         # arrange
         mock_configs = {"a": 1, "b": 2}
@@ -126,16 +126,18 @@ class TestHierarchicalConf:
         # assert
         assert content == expected_content
 
-    def test__validate_if_config_file_exists_with_error(self, hierarchical_conf):
+    def test__config_file_exists_with_non_existent_file(self, hierarchical_conf):
         # arrange
         path = "some_path"
 
-        # act & assert
-        with pytest.raises(FileNotFoundError):
-            hierarchical_conf._validate_if_config_file_exists(path)
+        # act
+        returned_value = hierarchical_conf._config_file_exists(path)
 
-    @mock.patch("hierarchical_conf.hierarchical_conf.os.path.isfile")
-    def test__validate_if_config_file_exists_without_error(
+        # assert
+        assert not returned_value
+
+    @mock.patch("hierarchical_conf.hierarchical_conf.isfile")
+    def test__config_file_exists_with_file(
         self, mock_is_file, hierarchical_conf
     ):
         # arrange
@@ -143,9 +145,10 @@ class TestHierarchicalConf:
         mock_is_file.return_value = True
 
         # act
-        hierarchical_conf._validate_if_config_file_exists(path)
+        returned_value = hierarchical_conf._config_file_exists(path)
 
         # assert
+        assert returned_value
         mock_is_file.assert_called_once_with(path)
 
     @mock.patch.dict(os.environ, {}, clear=True)

--- a/tests/unit/test_hierarchical_conf.py
+++ b/tests/unit/test_hierarchical_conf.py
@@ -84,9 +84,7 @@ class TestHierarchicalConf:
 
     @mock.patch.object(HierarchicalConf, "_config_file_exists")
     @mock.patch.object(HierarchicalConf, "_read_configuration")
-    def test_existent_config(
-        self, mock_read_configuration, mock_config_file_exists
-    ):
+    def test_existent_config(self, mock_read_configuration, mock_config_file_exists):
         # arrange
         mock_configs = {"a": 1, "b": 2}
 
@@ -99,9 +97,7 @@ class TestHierarchicalConf:
 
     @mock.patch.object(HierarchicalConf, "_config_file_exists")
     @mock.patch.object(HierarchicalConf, "_read_configuration")
-    def test_nonexistent_config(
-        self, mock_read_configuration, mock_config_file_exists
-    ):
+    def test_nonexistent_config(self, mock_read_configuration, mock_config_file_exists):
         # arrange
         mock_configs = {"a": 1, "b": 2}
 
@@ -137,9 +133,7 @@ class TestHierarchicalConf:
         assert not returned_value
 
     @mock.patch("hierarchical_conf.hierarchical_conf.isfile")
-    def test__config_file_exists_with_file(
-        self, mock_is_file, hierarchical_conf
-    ):
+    def test__config_file_exists_with_file(self, mock_is_file, hierarchical_conf):
         # arrange
         path = ""
         mock_is_file.return_value = True


### PR DESCRIPTION
## Why? :open_book:
When a user uses the lib, they don't necessarily have files instead of the configuration directories. So we must not raise errors when no file is found, instead, the better approach is only to load files if they exist.

## What? :wrench:
- remove breaking validations
- add a check to only load file if it exists

## Type of change :file_cabinet:
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Release

## How everything was tested? :straight_ruler:
Locally and with unit and integration tests

## Checklist :memo:
- [ ] I have added labels to distinguish the type of pull request.
- [ ] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [ ] I have performed a self-review of my own code;
- [ ] I have made corresponding changes to the documentation;
- [ ] I have added tests that prove my fix is effective or that my feature works;
- [ ] I have made sure that new and existing unit tests pass locally with my changes;

## Attention Points :warning:
_Replace me for what the reviewer will need to pay attention to in the PR or just to cover any concerns after the merge._
