### PR TITLE
[DIN] Removed warning log

### DIFF
--- a/hierarchical_conf/hierarchical_conf.py
+++ b/hierarchical_conf/hierarchical_conf.py
@@ -1,5 +1,4 @@
 """Hierarchical Conf main class."""
-import logging
 import os
 from collections.abc import Mapping
 from os.path import isfile
@@ -86,10 +85,6 @@ class HierarchicalConf:
         if isfile(config_file_path):
             return True
 
-        logging.warning(
-            f"msg=This configuration file was not found in the given path,"
-            f"file={config_file_path}"
-        )
         return False
 
     @staticmethod


### PR DESCRIPTION
## Why? :open_book:
Currently there is a warning log that prints about non-existent configuration files on every execution.
This is too verbose and is polluting multiple logs.

## What? :wrench:
- Removed both logging call and import.

## Type of change :file_cabinet:
- [x] Fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
Simple local installation in development mode on the branch:
`python3 -m pip install -e`
Import and call results in no logs.

## Checklist :memo:
- [x] I have added labels to distinguish the type of pull request.
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [ ] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] I have made sure that new and existing unit tests pass locally with my changes;
