### PR TITLE
[DIN-749] Add feature to delete nulls in overrides

### DIFF
--- a/hierarchical_conf/hierarchical_conf.py
+++ b/hierarchical_conf/hierarchical_conf.py
@@ -10,17 +10,16 @@ import yaml
 class HierarchicalConf:
     """User main interface with the lib operations."""
 
-    def __init__(self, searched_paths: List[str], delete_nulls: bool = False) -> None:
+    def __init__(self, searched_paths: List[str]) -> None:
         """
         Searches for the configuration files and load their values.
 
         :param searched_paths: the list of paths where the conf files will be
          searched
-        :param delete_nulls: whether keys with null values should be deleted
         """
         self._config_file_name = f"{self._get_environment()}_conf.yml"
         self._configuration_files = self._search_configurations_files(searched_paths)
-        self._configs = self._load_configurations_from_files(delete_nulls)
+        self._configs = self._load_configurations_from_files()
 
     @property
     def configs(self) -> Dict[str, Union[str, List[Any], Dict[str, Any]]]:
@@ -52,11 +51,11 @@ class HierarchicalConf:
 
         return env
 
-    def _load_configurations_from_files(self, delete_nulls=False) -> Dict[str, Any]:
+    def _load_configurations_from_files(self) -> Dict[str, Any]:
         configs = {}  # type: ignore
         for config_file in self._configuration_files:
             conf_content = self._read_configuration(config_file)
-            configs = self._deep_update(configs, conf_content, delete_nulls)
+            configs = self._deep_update(configs, conf_content)
 
         return configs
 
@@ -103,7 +102,6 @@ class HierarchicalConf:
         self,
         source: Dict[str, Any],
         overrides: MappingType[str, Any],
-        delete_nulls=False,
     ) -> Dict[str, Any]:
         """
         Updates the dicts given priority to the last loaded one.
@@ -121,7 +119,7 @@ class HierarchicalConf:
             if isinstance(value, Mapping) and value:
                 returned = self._deep_update(source.get(key, {}), value)
                 source[key] = returned
-            elif delete_nulls and value is None:
+            elif value is None:
                 source.pop(key, None)
             else:
                 source[key] = overrides[key]

--- a/hierarchical_conf/hierarchical_conf.py
+++ b/hierarchical_conf/hierarchical_conf.py
@@ -99,9 +99,7 @@ class HierarchicalConf:
             return yaml.safe_load(f)
 
     def _deep_update(
-        self,
-        source: Dict[str, Any],
-        overrides: MappingType[str, Any],
+        self, source: Dict[str, Any], overrides: MappingType[str, Any]
     ) -> Dict[str, Any]:
         """
         Updates the dicts given priority to the last loaded one.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 __package_name__ = "hierarchical_conf"
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 __repository_url__ = "https://github.com/quintoandar/hierarchical-conf"
 
 

--- a/tests/unit/test_hierarchical_conf.py
+++ b/tests/unit/test_hierarchical_conf.py
@@ -29,7 +29,7 @@ class TestHierarchicalConf:
         # assert
         mock_get_environment.assert_called_once_with()
         mock_search_configurations_files.assert_called_once_with(searched_paths)
-        mock_load_configurations_from_files.assert_called_once_with(False)
+        mock_load_configurations_from_files.assert_called_once_with()
 
     @mock.patch.object(HierarchicalConf, "_config_file_exists")
     @mock.patch.object(HierarchicalConf, "_read_configuration")
@@ -185,9 +185,7 @@ class TestHierarchicalConf:
         overrides = {"key1": None, "key2": "new value", "key3": {"a": 1}}
 
         # act
-        returned_value = hierarchical_conf._deep_update(
-            source, overrides, delete_nulls=True
-        )
+        returned_value = hierarchical_conf._deep_update(source, overrides)
 
         # assert
         assert returned_value == expected_value

--- a/tests/unit/test_hierarchical_conf.py
+++ b/tests/unit/test_hierarchical_conf.py
@@ -29,7 +29,7 @@ class TestHierarchicalConf:
         # assert
         mock_get_environment.assert_called_once_with()
         mock_search_configurations_files.assert_called_once_with(searched_paths)
-        mock_load_configurations_from_files.assert_called_once_with()
+        mock_load_configurations_from_files.assert_called_once_with(False)
 
     @mock.patch.object(HierarchicalConf, "_config_file_exists")
     @mock.patch.object(HierarchicalConf, "_read_configuration")
@@ -171,6 +171,23 @@ class TestHierarchicalConf:
 
         # act
         returned_value = hierarchical_conf._deep_update(source, overrides)
+
+        # assert
+        assert returned_value == expected_value
+
+    def test_deep_update_deleting_nulls(self, hierarchical_conf):
+        # arrange
+        expected_value = {"key2": "new value", "key3": {"a": 1}}
+        source = {
+            "key1": "val1",
+            "key2": "val2",
+        }
+        overrides = {"key1": None, "key2": "new value", "key3": {"a": 1}}
+
+        # act
+        returned_value = hierarchical_conf._deep_update(
+            source, overrides, delete_nulls=True
+        )
 
         # assert
         assert returned_value == expected_value


### PR DESCRIPTION
## Why? :open_book:
There is currently no way to remove a key that was previously added using overrides. This is a limitation that we can solve by removing null values.

## What? :wrench:
- Add feature to remove key if the value in the override is None
- Add unit test for new case
- Update version to 1.0.4

## Type of change :file_cabinet:

- [X] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
Unit tests

## Checklist :memo:
- [X] I have added labels to distinguish the type of pull request.
- [X] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [X] I have performed a self-review of my own code;
- [ ] I have made corresponding changes to the documentation;
- [X] I have added tests that prove my fix is effective or that my feature works;
- [X] I have made sure that new and existing unit tests pass locally with my changes;
